### PR TITLE
Fixed abandoned vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "symfony/event-dispatcher": "~2.3",
         "predis/predis": "~0.8",
-        "rhumsaa/uuid": "~2.7"
+        "ramsey/uuid": "~2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.2",


### PR DESCRIPTION
Fixed usage of abandoned vendor by its replacement. 

Warning was:
`Package rhumsaa/uuid is abandoned, you should avoid using it. Use ramsey/uuid instead.`