### PR TITLE
Add adapter rpop method

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -7,6 +7,7 @@ interface AdapterInterface
     public function incr($key);
     public function del($key);
     public function lpush($key, $value);
+    public function rpop($channel);
     public function brpop($channel, $timeout);
     public function lrem($key, $count, $value);
     public function rpoplpush($source, $destination);

--- a/src/Adapter/PhpRedisAdapter.php
+++ b/src/Adapter/PhpRedisAdapter.php
@@ -4,7 +4,6 @@ namespace Yoye\Broker\Adapter;
 
 class PhpRedisAdapter implements AdapterInterface
 {
-
     /**
      * @var \Redis
      */
@@ -13,6 +12,11 @@ class PhpRedisAdapter implements AdapterInterface
     public function __construct(\Redis $client)
     {
         $this->client = $client;
+    }
+
+    public function rpop($channel)
+    {
+        return $this->client->rPop($channel);
     }
 
     public function brpop($channel, $timeout)

--- a/src/Adapter/PredisAdapter.php
+++ b/src/Adapter/PredisAdapter.php
@@ -16,6 +16,11 @@ class PredisAdapter implements AdapterInterface
         $this->client = $client;
     }
 
+    public function rpop($channel)
+    {
+        return $this->client->rpop($channel);
+    }
+
     public function brpop($channel, $timeout)
     {
         return $this->client->brpop($channel, $timeout);


### PR DESCRIPTION
As `brpop` (blocking) is available, I think `rpop` should be too, especially if we don't need the blocking behaviour if no data is available.
